### PR TITLE
fix: revert release.yml semantic-release flags to correct syntax  The…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         id: release-check
         run: |
           # Check if there are any releasable changes
-          if uv run semantic-release version --no-op --strict; then
+          if uv run semantic-release --noop --strict version; then
             echo "release_needed=true" >> $GITHUB_OUTPUT
             echo "Release will be created"
           else


### PR DESCRIPTION
… --noop and --strict are GLOBAL options (not subcommand options), so they must come BEFORE 'version'. Previous 'fix' broke the command. - --noop (correct) vs --no-op (doesn't exist) - Global flags before subcommand: --noop --strict version