### PR TITLE
fix: remove unused open-terminal dependency (requires 3.11)  open-ter…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "baostock>=0.8.9",
     "litellm>=1.81.14",
     "websockets>=16.0",
-    "open-terminal>=0.10.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
…minal is not imported anywhere in qka source code.